### PR TITLE
explicitly define all fields in ghud vec3s

### DIFF
--- a/src/client/screen.c
+++ b/src/client/screen.c
@@ -2054,8 +2054,10 @@ static void SCR_DrawGhud(void)
 			vec3_t pos, xhair;
 			pos[0] = x;
 			pos[1] = y;
+			pos[2] = 0;
 			xhair[0] = scr.hud_width / 2;
 			xhair[1] = scr.hud_height / 2;
+			xhair[2] = 0;
 
 			float scale_dimension = min(scr.hud_width, scr.hud_height) / 6;
 			VectorSubtract(pos, xhair, pos);

--- a/src/server/game.c
+++ b/src/server/game.c
@@ -802,6 +802,7 @@ extension_func_t *g_extension_funcs;
 				g_extension_funcs = ext; \
 				} while (0);
 
+int(*GE_customizeentityforclient)(edict_t *client, edict_t *ent, entity_state_t *state);
 
 /*
 ================

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -809,7 +809,7 @@ void SV_Ghud_SetSize(int i, int x, int y);
 #endif
 
 #ifdef AQTION_EXTENSION
-int(*GE_customizeentityforclient)(edict_t *client, edict_t *ent, entity_state_t *state); // 0 don't send, 1 send normally
+extern int(*GE_customizeentityforclient)(edict_t *client, edict_t *ent, entity_state_t *state); // 0 don't send, 1 send normally
 #endif
 
 //============================================================


### PR DESCRIPTION
fix for compiler error when compiler expects explicit declaration of all 3 fields of vec3