### PR TITLE
Strip quotes from ‘if’ command arguments.

### DIFF
--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -468,6 +468,7 @@ int SortStricmp(const void *p1, const void *p2);
 
 size_t COM_strclr(char *s);
 char *COM_StripQuotes(char *s);
+char *COM_Trim(char *s);
 
 // buffer safe operations
 size_t Q_strlcpy(char *dst, const char *src, size_t size);

--- a/src/common/cmd.c
+++ b/src/common/cmd.c
@@ -658,12 +658,12 @@ error:
     if (matched) {
         // execute branch 1
         if (i > j) {
-            Cbuf_InsertText(cmd_current, Cmd_RawArgsFrom(j));
+            Cbuf_InsertText(cmd_current, COM_StripQuotes(COM_Trim(Cmd_RawArgsFrom(j))));
         }
     } else {
         // execute branch 2
         if (++i < Cmd_Argc()) {
-            Cbuf_InsertText(cmd_current, Cmd_RawArgsFrom(i));
+            Cbuf_InsertText(cmd_current, COM_StripQuotes(Cmd_RawArgsFrom(i)));
         }
     }
 }

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -348,6 +348,21 @@ char *COM_StripQuotes(char *s)
     return s;
 }
 
+char *COM_Trim(char *s)
+{
+    size_t len;
+
+    while (*s && *s <= ' ')
+        s++;
+
+    len = strlen(s);
+    while (len > 0 && s[len - 1] <= ' ')
+        len--;
+
+    s[len] = 0;
+    return s;
+}
+
 /*
 ============
 va


### PR DESCRIPTION
Fixes backward compatibility issue introduced by commit f4faabd7. Fixes #297.