### PR TITLE
Allow grenade pin pull during LCA

### DIFF
--- a/src/action/g_local.h
+++ b/src/action/g_local.h
@@ -1289,6 +1289,7 @@ extern cvar_t *sv_killgib; // Enable or disable gibbing on kill command
 extern cvar_t *warmup_unready;
 extern cvar_t *training_mode; // Sets training mode vars
 extern cvar_t *g_highscores_dir; // Sets the highscores directory
+extern cvar_t *lca_grenade; // Allows grenade pin pulling during LCA
 
 #if AQTION_EXTENSION
 extern int (*engine_Client_GetVersion)(edict_t *ent);

--- a/src/action/g_main.c
+++ b/src/action/g_main.c
@@ -533,6 +533,7 @@ cvar_t *sv_killgib; // Gibs on 'kill' command
 cvar_t *warmup_unready; // Toggles warmup if captains unready
 cvar_t *training_mode; // Sets training mode vars
 cvar_t *g_highscores_dir; // Sets the highscores directory
+cvar_t *lca_grenade; // Allows grenade pin pulling during LCA
 
 #if AQTION_EXTENSION
 cvar_t *use_newirvision;

--- a/src/action/g_save.c
+++ b/src/action/g_save.c
@@ -652,6 +652,8 @@ void InitGame( void )
 		gi.cvar_forceset("bholelimit", "30");
 	}
 	g_highscores_dir = gi.cvar("g_highscores_dir", "highscores", 0);
+	lca_grenade = gi.cvar("lca_grenade", "0", 0);
+
 
 	// new AQtion Extension cvars
 #if AQTION_EXTENSION

--- a/src/action/p_weapon.c
+++ b/src/action/p_weapon.c
@@ -3782,10 +3782,8 @@ void Weapon_Gas(edict_t* ent)
 	{
 		if (((ent->client->latched_buttons | ent->client->buttons) & BUTTON_ATTACK)
 			&& (ent->solid != SOLID_NOT || ent->deadflag == DEAD_DEAD) &&
-			!lights_camera_action && !ent->client->uvTime)
+			!ent->client->uvTime && (lca_grenade->value || !lights_camera_action))
 		{
-
-
 			if (ent->client->ps.gunframe <= GRENADE_PINIDLE_LAST &&
 				ent->client->ps.gunframe >= GRENADE_PINIDLE_FIRST)
 			{
@@ -3808,14 +3806,18 @@ void Weapon_Gas(edict_t* ent)
 		if (ent->client->ps.gunframe >= GRENADE_IDLE_FIRST &&
 			ent->client->ps.gunframe <= GRENADE_IDLE_LAST)
 		{
-			ent->client->ps.gunframe = GRENADE_THROW_FIRST;
-			if (ent->client->ps.pmove.pm_flags & PMF_DUCKED)
-				SetAnimation( ent, FRAME_crattak1 - 1, FRAME_crattak9, ANIM_ATTACK );
-			else
-				SetAnimation( ent, FRAME_attack1 - 1, FRAME_attack8, ANIM_ATTACK );
-			ent->client->weaponstate = WEAPON_FIRING;
+			// Only allow the player to throw the grenade if lights_camera_action is 0
+			// This is so we can enable lca_grenade
+			if (!lights_camera_action)
+			{
+				ent->client->ps.gunframe = GRENADE_THROW_FIRST;
+				if (ent->client->ps.pmove.pm_flags & PMF_DUCKED)
+					SetAnimation( ent, FRAME_crattak1 - 1, FRAME_crattak9, ANIM_ATTACK );
+				else
+					SetAnimation( ent, FRAME_attack1 - 1, FRAME_attack8, ANIM_ATTACK );
+				ent->client->weaponstate = WEAPON_FIRING;
+			}
 			return;
-
 		}
 
 		if (ent->client->ps.gunframe == GRENADE_PINIDLE_LAST)


### PR DESCRIPTION
Does not throw the grenade during LCA, but will immediately throw it if the button is released once LCA is completed, or continue to hold the attack button as normal.

You can drop the grenade during LCA if you, as soon as the announcer says LIGHTS...:
1. Switch from your weapon to grenade
2. Pull the pin of the grenade
3. Switch to another weapon
The grenade will drop sometime between CAMERA and ACTION

The explosion will still occur after ACTION, but the grenade will drop so close to the player who pulled the pin that it would only be useful in suicide runs.