### PR TITLE
Fixed an issue in CL_PlayFootstepSfx where it always played a random …

### DIFF
--- a/src/client/entities.c
+++ b/src/client/entities.c
@@ -224,22 +224,6 @@ static void parse_entity_event(int number)
         break;
     case EV_FOOTSTEP:
         if (cl_footsteps->integer) {
-            if (strcmp(cl_enhanced_footsteps->string, "0") == 0) {
-                CL_PlayFootstepSfx(-1, number, 1.0f, ATTN_NORM);
-                //S_StartSound(NULL, number, CHAN_BODY, cl_sfx_footsteps[Q_rand() & 3], 1, ATTN_NORM, 0);
-            } else {
-                int r = Q_rand() % 12;
-                if ( r == cl_laststep ) {
-                    if ( r < 11) {
-                        r++; //use next step if same as last time was generated
-                    } else {
-                        r = 0; //use first stepsound if 12 where used twice
-                    }
-                }
-                CL_PlayFootstepSfx(-1, number, 1.0f, ATTN_NORM);
-                //S_StartSound(NULL, number, CHAN_BODY, cl_sfx_footsteps[r], 1, ATTN_NORM, 0);
-                cl_laststep = r;
-            }
             CL_PlayFootstepSfx(-1, number, 1.0f, ATTN_NORM);
         }
         break;
@@ -627,9 +611,9 @@ static void CL_AddPacketEntities(void)
         }
 
 #if USE_AQTION
-		if (IS_INDICATOR(renderfx) && !cl_indicators->integer && cls.demo.playback) {
-			goto skip;
-		}
+        if (IS_INDICATOR(renderfx) && !cl_indicators->integer && cls.demo.playback) {
+            goto skip;
+        }
 #endif
         if ((effects & EF_GIB) && !cl_gibs->integer)
             goto skip;
@@ -1323,7 +1307,7 @@ void CL_CalcViewValues(void)
         float backlerp = lerp - 1.0f;
 
         VectorMA(cl.predicted_origin, backlerp, cl.prediction_error, cl.refdef.vieworg);
-		LerpVector(ops->viewoffset, ps->viewoffset, lerp, viewoffset);
+        LerpVector(ops->viewoffset, ps->viewoffset, lerp, viewoffset);
 
         // smooth out stair climbing
         if (cl.predicted_step < 127 * 0.125f) {
@@ -1333,16 +1317,16 @@ void CL_CalcViewValues(void)
             cl.refdef.vieworg[2] -= cl.predicted_step * (100 - delta) * 0.01f;
         }
 
-		if (cl_predict_crouch->integer == 2 || (cl_predict_crouch->integer && cl.view_predict))
-		{
+        if (cl_predict_crouch->integer == 2 || (cl_predict_crouch->integer && cl.view_predict))
+        {
 #if USE_FPS
-			viewoffset[2] = cl.predicted_viewheight[1];
-			viewoffset[2] -= (cl.predicted_viewheight[1] - cl.predicted_viewheight[0]) * cl.keylerpfrac;
+            viewoffset[2] = cl.predicted_viewheight[1];
+            viewoffset[2] -= (cl.predicted_viewheight[1] - cl.predicted_viewheight[0]) * cl.keylerpfrac;
 #else
-			viewoffset[2] = cl.predicted_viewheight[1];
-			viewoffset[2] -= (cl.predicted_viewheight[1] - cl.predicted_viewheight[0]) * lerp;
+            viewoffset[2] = cl.predicted_viewheight[1];
+            viewoffset[2] -= (cl.predicted_viewheight[1] - cl.predicted_viewheight[0]) * lerp;
 #endif
-		}
+        }
 
     } else {
         int i;
@@ -1353,7 +1337,7 @@ void CL_CalcViewValues(void)
                 lerp * (ps->pmove.origin[i] - ops->pmove.origin[i]));
         }
 
-		LerpVector(ops->viewoffset, ps->viewoffset, lerp, viewoffset);
+        LerpVector(ops->viewoffset, ps->viewoffset, lerp, viewoffset);
     }
 
     // if not running a demo or on a locked frame, add the local angle movement

--- a/src/client/tent.c
+++ b/src/client/tent.c
@@ -161,8 +161,15 @@ void CL_PlayFootstepSfx(int step_id, int entnum, float volume, float attenuation
     if (!sfx->num_sfx)
         return; // no footsteps, not even fallbacks
 
-    // pick a random footstep sound, but avoid playing the same one twice in a row
-    sfx_num = Q_rand_uniform(sfx->num_sfx);
+    // check if cl_enhanced_footsteps->string is "0" and sfx->num_sfx has more than four items
+    if (strcmp(cl_enhanced_footsteps->string, "0") == 0 && sfx->num_sfx > 4) {
+        // pick a random footstep sound from the first four items, important for compatibility with players using the old four stepsounds
+        sfx_num = Q_rand_uniform(4);
+    } else {
+        // pick a random footstep sound
+        sfx_num = Q_rand_uniform(sfx->num_sfx);
+    }
+    // avoid playing the same one twice in a row
     footstep_sfx = sfx->sfx[sfx_num];
     if (footstep_sfx == cl_last_footstep)
         footstep_sfx = sfx->sfx[(sfx_num + 1) % sfx->num_sfx];


### PR DESCRIPTION
…step sound from all loaded step sounds in the player's sound directory. This was problematic because the default pak-file for action now contains twelve step sounds, unintentionally activating the func cl_enhanced_footsteps for everyone. This was not optimal as many players have only four original step sounds in their personal pak-files, resulting in the player having their personal step1.wav - step4.wav mixed up with step5 - step12.wav from baseaq/pak0.pkz

To address this, the use of the cvar cl_enhanced_footsteps has been enforced. Now, it must be set to 1 for CL_PlayFootstepSfx to play more than the first four step#.wav sounds.