### PR TITLE
Fixed Espionage bugs

### DIFF
--- a/src/action/a_game.c
+++ b/src/action/a_game.c
@@ -255,9 +255,16 @@ qboolean PrintGameMessage(edict_t *ent)
 		in order to begin the match.  Once both teams have leaders, this message will no longer be printed.
 	*/
 	if (esp->value) {
+		edict_t* t1leader = HAVE_LEADER(TEAM1) ? teams[TEAM1].leader : NULL;
+		edict_t* t2leader = HAVE_LEADER(TEAM2) ? teams[TEAM2].leader : NULL;
+		edict_t* t3leader = HAVE_LEADER(TEAM3) ? teams[TEAM3].leader : NULL;
+
 		if (!team_round_going && !AllTeamsHaveLeaders()) {
 			if (atl->value) {
-				Q_snprintf(msg_buf, sizeof(msg_buf), "Waiting for each team to have a leader\nType 'leader' in console to volunteer for duty.\n");
+				if (teamCount == 2)
+					Q_snprintf(msg_buf, sizeof(msg_buf), "Waiting for each team to have a leader\nType 'leader' in console to volunteer for duty.\n\n Team 1 Leader: %s\n Team 2 Leader: %s", t1leader ? t1leader->client->pers.netname : "None", t2leader ? t2leader->client->pers.netname : "None");
+				else if (teamCount == 3)
+					Q_snprintf(msg_buf, sizeof(msg_buf), "Waiting for each team to have a leader\nType 'leader' in console to volunteer for duty.\n\n Team 1 Leader: %s\n Team 2 Leader: %s\n Team 3 Leader: %s", t1leader ? t1leader->client->pers.netname : "None", t2leader ? t2leader->client->pers.netname : "None", t3leader ? t3leader->client->pers.netname : "None");
 				msg_ready = true;
 			} else if (etv->value) {
 				if (ent->client->resp.team == TEAM1)

--- a/src/action/a_team.c
+++ b/src/action/a_team.c
@@ -2026,7 +2026,7 @@ int TeamHasPlayers (int team)
 
 int _numclients( void );  // a_vote.c
 
-qboolean BothTeamsHavePlayers(void)
+qboolean AllTeamsHavePlayers(void)
 {
 	int players[TEAM_TOP] = { 0 }, i, teamsWithPlayers;
 	edict_t *ent;
@@ -2094,20 +2094,34 @@ int CheckForWinner(void)
 		if (atl->value) {
 			if (teamCount == TEAM2) {
 				if (teams[TEAM1].leader_dead && teams[TEAM2].leader_dead) {
+					if (esp_debug->value)
+						gi.dprintf("Both leaders are dead\n");
 					return WINNER_TIE;
 				} else if (teams[TEAM1].leader_dead) {
+					if (esp_debug->value)
+						gi.dprintf("Team 2 leader is alive\n");
 					return TEAM2;
 				} else if (teams[TEAM2].leader_dead) {
+					if (esp_debug->value)
+						gi.dprintf("Team 1 leader is alive\n");
 					return TEAM1;
 				}
 			} else if (teamCount == TEAM3) {
 				if (teams[TEAM1].leader_dead && teams[TEAM2].leader_dead && teams[TEAM3].leader_dead) {
+					if (esp_debug->value)
+						gi.dprintf("All leaders are dead\n");
 					return WINNER_TIE;
 				} else if (teams[TEAM1].leader_dead && teams[TEAM2].leader_dead) {
+					if (esp_debug->value)
+						gi.dprintf("Team 3 leader is alive\n");
 					return TEAM3;
 				} else if (teams[TEAM1].leader_dead && teams[TEAM3].leader_dead) {
+					if (esp_debug->value)
+						gi.dprintf("Team 2 leader is alive\n");
 					return TEAM2;
 				} else if (teams[TEAM2].leader_dead && teams[TEAM3].leader_dead) {
+					if (esp_debug->value)
+						gi.dprintf("Team 1 leader is alive\n");
 					return TEAM1;
 				} 
 			}
@@ -2818,16 +2832,16 @@ int CheckTeamRules (void)
 		team_round_countdown--;
 		if(!team_round_countdown)
 		{
-			if (!esp->value && BothTeamsHavePlayers())
+			if (!esp->value && AllTeamsHavePlayers())
 			{
 				in_warmup = 0;
 				team_game_going = 1;
 				StartLCA();
 			}
-			else if (esp->value && AllTeamsHaveLeaders() && BothTeamsHavePlayers())
+			else if (esp->value && AllTeamsHaveLeaders() && AllTeamsHavePlayers())
 			{
 				if (esp_debug->value)
-					gi.dprintf("%s: Esp mode on, All teams have leaders, Both teams have players\n", __FUNCTION__);
+					gi.dprintf("%s: Esp mode on, All teams have leaders, all teams have players\n", __func__);
 				in_warmup = 0;
 				team_game_going = 1;
 				StartLCA();
@@ -2971,7 +2985,7 @@ int CheckTeamRules (void)
 
 		if (!team_round_countdown)
 		{
-			if (BothTeamsHavePlayers() || (esp->value && AllTeamsHaveLeaders() && BothTeamsHavePlayers()))
+			if (AllTeamsHavePlayers() || (esp->value && AllTeamsHaveLeaders() && AllTeamsHavePlayers()))
 			{
 				if (use_tourney->value)
 				{
@@ -2983,7 +2997,7 @@ int CheckTeamRules (void)
 				{
 					int warmup_length = max( warmup->value, round_begin->value );
 					char buf[64] = "";
-					if (esp->value && BothTeamsHavePlayers()) {
+					if (esp->value && AllTeamsHavePlayers()) {
 						sprintf( buf, "All teams are ready!\nThe round will begin in %d seconds!", warmup_length );
 					} else {
 						sprintf( buf, "The round will begin in %d seconds!", warmup_length );
@@ -3035,14 +3049,15 @@ int CheckTeamRules (void)
 				return 1;
 			}
 
-			if (!BothTeamsHavePlayers() || (esp->value && !AllTeamsHaveLeaders()))
+			if (!AllTeamsHavePlayers() || (esp->value && !AllTeamsHaveLeaders()))
 			{
-				if (!matchmode->value || TeamsReady())
+				if (!matchmode->value || TeamsReady()) {
 					CenterPrintAll( "Not enough players to play!" );
-				else if (esp->value && !AllTeamsHaveLeaders())
+				} else if (esp->value && !AllTeamsHaveLeaders()) {
 					CenterPrintAll ("Both Teams Must Have a Leader!\nType 'leader' in console to volunteer!");
-				else
+				} else {
 					CenterPrintAll( "Both Teams Must Be Ready!" );
+				}
 
 				team_round_going = team_round_countdown = team_game_going = 0;
 				MakeAllLivePlayersObservers();

--- a/src/action/g_ext.c
+++ b/src/action/g_ext.c
@@ -103,13 +103,13 @@ int G_customizeentityforclient(edict_t *clent, edict_t *ent, entity_state_t *sta
 			return false;
 
 		// Espionage allows indicators for leaders if set to 2
-		if (esp->value && use_indicators->value == 2 && esp_showleader->value && clent->client->resp.team) {
-			// Quad is a blue glow, pent is a red glow
-			if (clent->client->resp.team == TEAM1 && IS_LEADER(clent))
-				ent->s.effects = EF_PENT;
-			else if (clent->client->resp.team == TEAM2 && IS_LEADER(clent))
-				ent->s.effects = EF_QUAD;
-		}
+		// if (esp->value && use_indicators->value == 2 && esp_showleader->value && clent->client->resp.team) {
+		// 	// Quad is a blue glow, pent is a red glow
+		// 	if (clent->client->resp.team == TEAM1 && IS_LEADER(clent))
+		// 		ent->s.effects = EF_PENT;
+		// 	else if (clent->client->resp.team == TEAM2 && IS_LEADER(clent))
+		// 		ent->s.effects = EF_QUAD;
+		// }
 		if ((use_indicators->value == 2 && clent->client->resp.team) || (clent->client->resp.team && clent->client->pers.cl_indicators != 2)) // disallow indicators for players in use_indicators 2, and don't use them for players unless cl_indicators 2
 			return false;
 


### PR DESCRIPTION
1. Fixed bug where if last member of team was leader and quit mid-game, the round would continue forever.  Now it ends immediately
2. Fixed bug where if leader left the team in mid-game, then returned, would declare the team had a leader, but the leader was dead, automatically awarding the other team the win
3. Renamed a function
4. Added more verbose messaging about leaders

Existing bug: Arrow indicators over everyone, and can see through solids