### PR TITLE
Added teamnone command

### DIFF
--- a/doc/action.md
+++ b/doc/action.md
@@ -241,7 +241,8 @@ Clients will have a few more things to do during matchmode: they have to have a 
   - `sub` - this will make you a sub for the team or remove you from the subs and back in the team
   - `ready` - this will ready/unready the team. A new round won't start if a team isn't read
   - `teamname "name"` - allows the captain to set the name of his/her team
-  - `teamskin "male/resdog"` - allows the captain to set the name of his/her team 
+  - `teamskin "male/resdog"` - allows the captain to set the name of his/her team
+  - `teamnone <#>` - Using 'playerlist' to determine player numbers, use this to remove players from your team (send them to team 0), usable by Captains
   - `matchadmin <pass>` - this will allow a player to get admin status
   - `lock` - allows a captain to lock his team. When a team is locked, no one can join it. Locks are removed on a new map
   - `unlock` - allows a captain to unlock his team

--- a/src/action/a_match.c
+++ b/src/action/a_match.c
@@ -528,6 +528,12 @@ void Cmd_Teamnone_f(edict_t *ent)
 			gi.cprintf(ent, PRINT_HIGH, "You cannot remove bots in this way, use the sv bot commands\n");
 			return;
 		}
+		// This should never happen but just in case...
+		if (esp->value && IS_LEADER(target)){
+			gi.cprintf(ent, PRINT_HIGH, "You cannot remove the leader of your team\n");
+			return;
+		}
+
 		// Finally, after all the checks, remove the player from your team
 		gi.bprintf(PRINT_HIGH, "%s removed %s (clientNum %i) from team %i\n", ent->client->pers.netname, target->client->pers.netname, playernum, target->client->resp.team);
 		JoinTeam(target, NOTEAM, 1);

--- a/src/action/a_match.c
+++ b/src/action/a_match.c
@@ -465,6 +465,78 @@ void Cmd_Teamskin_f(edict_t * ent)
 	gi.cprintf(ent, PRINT_HIGH, "New team skin: %s\n", team->skin);
 }
 
+void Cmd_Teamnone_f(edict_t *ent)
+{
+	int i;
+	edict_t *other, *target;
+
+	if (!matchmode->value) {
+		gi.cprintf(ent, PRINT_HIGH, "This command needs matchmode to be enabled\n");
+		return;
+	}
+
+	if (ent->client->resp.team == NOTEAM) {
+		gi.cprintf(ent, PRINT_HIGH, "You need to be on a team for that...\n");
+		return;
+	}
+
+	if (!IS_CAPTAIN(ent)) {
+		gi.cprintf(ent, PRINT_HIGH, "You are not the captain of your team\n");
+		return;
+	}
+
+	if (gi.argc() < 1) {
+		gi.cprintf(ent, PRINT_HIGH, "You need to provide a playernum for this command\nUse 'playerlist' to get a list of playernums\n");
+		return;
+	}
+
+	if (gi.argc() > 2) {
+		gi.cprintf(ent, PRINT_HIGH, "You can only specify one playernum for this command\n");
+		return;
+	}
+
+	int playernum = atoi(gi.argv(1));
+
+	// Get entity of the playernum
+	target = NULL;
+	for (i = 0, other = &g_edicts[1]; i < game.maxclients; i++, other++) {
+		if (!other->inuse || !other->client || other->is_bot) // Do not count bots
+			continue;
+		if (other->client->clientNum == playernum) {
+			target = other;
+			break;
+		}
+	}
+
+	if (target != NULL) {
+		if (target == ent || target->client->clientNum == ent->client->clientNum) {
+			gi.cprintf(ent, PRINT_HIGH, "If you want to leave so badly, just do it the old fashioned way!\n");
+			return;
+		}
+
+		if (target->client->resp.team == NOTEAM) {
+			gi.cprintf(ent, PRINT_HIGH, "Player %i (%s) is not on a team\n", playernum, target->client->pers.netname);
+			return;
+		}
+
+		if (target->client->resp.team != ent->client->resp.team) {
+			gi.cprintf(ent, PRINT_HIGH, "You cannot remove a player from the other team\n");
+			return;
+		}
+		
+		if (target->is_bot) {
+			gi.cprintf(ent, PRINT_HIGH, "You cannot remove bots in this way, use the sv bot commands\n");
+			return;
+		}
+		// Finally, after all the checks, remove the player from your team
+		gi.bprintf(PRINT_HIGH, "%s removed %s (clientNum %i) from team %i\n", ent->client->pers.netname, target->client->pers.netname, playernum, target->client->resp.team);
+		JoinTeam(target, NOTEAM, 1);
+	} else {
+		gi.cprintf(ent, PRINT_HIGH, "Player %i not found, check `playerlist`\n", playernum);
+		return;
+	}
+}
+
 void Cmd_TeamLock_f(edict_t *ent, int a_switch)
 {
 	char msg[128], *s;

--- a/src/action/a_match.h
+++ b/src/action/a_match.h
@@ -33,6 +33,7 @@ void Cmd_Ready_f (edict_t * ent);
 void Cmd_Sub_f (edict_t * ent);
 void Cmd_Teamname_f (edict_t * ent);
 void Cmd_Teamskin_f (edict_t * ent);
+void Cmd_Teamnone_f (edict_t * ent);
 void Cmd_TeamLock_f (edict_t * ent, int a_switch);
 int CheckForCaptains (int cteam);
 

--- a/src/action/g_cmds.c
+++ b/src/action/g_cmds.c
@@ -1523,8 +1523,26 @@ static void Cmd_PlayerList_f (edict_t * ent)
 	char st[64];
 	char text[1024] = { 0 };
 	edict_t *e2;
+	int header_settings = 0;
 
 	// connect time, ping, score, name
+
+	// Set appropriate header based on settings
+	if (limchasecam->value) {
+		Q_snprintf(st, sizeof(st), "%-5s  %-3s %-3s %-16s\n", "Time", "Ping", "Team", "Name");
+		header_settings = 1;
+	} else if (matchmode->value && IS_CAPTAIN(ent)) {
+		Q_snprintf(st, sizeof(st), "%-5s  %-3s %-3s %-16s\n", "Time", "Ping", "Num", "Name");
+		header_settings = 2;
+	} else if (!teamplay->value || !noscore->value) {
+		Q_snprintf(st, sizeof(st), "%-5s  %-3s %-5s %-16s\n", "Time", "Ping", "Score", "Name");
+		header_settings = 3;
+	} else {
+		Q_snprintf(st, sizeof(st), "%-5s  %-3s %-16s\n", "Time", "Ping", "Name");
+		header_settings = 0;
+	}
+	// Print the header
+	gi.cprintf(ent, PRINT_HIGH, "%s", st);
 
 	// Set the lines:
 	for (i = 0, e2 = g_edicts + 1; i < game.maxclients; i++, e2++)
@@ -1535,12 +1553,15 @@ static void Cmd_PlayerList_f (edict_t * ent)
 		if (!e2->inuse || !e2->client || e2->client->pers.mvdspec)
 			continue;
 
-		if(limchasecam->value)
-			Q_snprintf (st, sizeof (st), "%02d:%02d %4d %3d %s\n", minutes, seconds, e2->client->ping, e2->client->resp.team, e2->client->pers.netname); // This shouldn't show player's being 'spectators' during games with limchasecam set and/or during matchmode
-		else if (!teamplay->value || !noscore->value)
-			Q_snprintf (st, sizeof (st), "%02d:%02d %4d %3d %s%s\n", minutes, seconds, e2->client->ping, e2->client->resp.score, e2->client->pers.netname, (e2->solid == SOLID_NOT && e2->deadflag != DEAD_DEAD) ? " (dead)" : ""); // replaced 'spectator' with 'dead'
+		// Set the lines with fixed width columns:
+		if(header_settings == 1)
+			Q_snprintf(st, sizeof(st), "%02d:%02d  %-3d  %-3d  %-16s\n", minutes, seconds, e2->client->ping, e2->client->resp.team, e2->client->pers.netname);
+		else if (header_settings == 2)
+			Q_snprintf(st, sizeof(st), "%02d:%02d  %-3d  %-3d  %-16s\n", minutes, seconds, e2->client->ping, e2->client->clientNum, e2->client->pers.netname);
+		else if (header_settings == 3)
+			Q_snprintf(st, sizeof(st), "%02d:%02d  %-3d  %-5d  %-16s%s\n", minutes, seconds, e2->client->ping, e2->client->resp.score, e2->client->pers.netname, (e2->solid == SOLID_NOT && e2->deadflag != DEAD_DEAD) ? " (dead)" : "");
 		else
-			Q_snprintf (st, sizeof (st), "%02d:%02d %4d %s%s\n", minutes, seconds, e2->client->ping, e2->client->pers.netname, (e2->solid == SOLID_NOT && e2->deadflag != DEAD_DEAD) ? " (dead)" : ""); // replaced 'spectator' with 'dead'
+			Q_snprintf(st, sizeof(st), "%02d:%02d  %-3d  %-16s%s\n", minutes, seconds, e2->client->ping, e2->client->pers.netname, (e2->solid == SOLID_NOT && e2->deadflag != DEAD_DEAD) ? " (dead)" : "");
 
 		if (strlen(text) + strlen(st) > sizeof(text) - 6)
 		{
@@ -1960,6 +1981,7 @@ static cmdList_t commandList[] =
 	{ "ready", Cmd_Ready_f, 0 },
 	{ "teamname", Cmd_Teamname_f, 0 },
 	{ "teamskin", Cmd_Teamskin_f, 0 },
+	{ "teamnone", Cmd_Teamnone_f, 0 },
 	{ "lock", Cmd_LockTeam_f, 0 },
 	{ "unlock", Cmd_UnlockTeam_f, 0 },
 	{ "entcount", Cmd_Ent_Count_f, 0 },


### PR DESCRIPTION
To _gently_ remove players from matchmode games who aren't meant to be in them, team captains can remove the players from their own teams using this `teamnone` command.  To use it:

`>teamnone <#>` in the console

The argument you provide is the player number of the person you want to move to team 0.  You can find this player number only as the captain of the team (or if you have rcon) with the command `playerlist`

Stipulations for using the command:
- The game mode must be `matchmode`
- Command issuer must be on a team
- Command issuer must be the captain of a team
- You can only move one player at a time
- Player cannot be a bot (use the bot commands to move bots around)
- You cannot remove yourself from a team using this command
- The target must be on a team
- The target must not be the Leader (Espionage mode), this should not happen because Captains are perma-leaders, but I added it here just in case
- The target of the command must be on the same team as the command issuer (so captains cannot remove players from other teams)

Basically, if you're the captain and you want to remove someone from your team, get their player number from the `playerlist` command, and enter `teamnone #` where # is their player number.  This will broadcast a message to the server that you have removed that player from the team.