### PR TITLE
auto_menu 2 and gl_shader check

### DIFF
--- a/src/action/a_game.c
+++ b/src/action/a_game.c
@@ -702,10 +702,15 @@ void PrintMOTD(edict_t * ent)
 		}
 	}
 
-	if (!auto_menu->value || ent->client->pers.menu_shown) {
+	// Print the MOTD
+	if (auto_menu->value == 2) {
 		gi.centerprintf(ent, "%s", msg_buf);
 	} else {
-		gi.cprintf(ent, PRINT_LOW, "%s", msg_buf);
+       if (!auto_menu->value || ent->client->pers.menu_shown) {
+               gi.centerprintf(ent, "%s", msg_buf);
+       } else {
+               gi.cprintf(ent, PRINT_LOW, "%s", msg_buf);
+       }
 	}
 }
 

--- a/src/action/p_client.c
+++ b/src/action/p_client.c
@@ -6198,8 +6198,15 @@ void ClientBeginServerFrame(edict_t * ent)
 		}
 	}
 
-	// show team or weapon menu immediately when connected
-	if (auto_menu->value && ent->client->layout != LAYOUT_MENU && !client->pers.menu_shown && (teamplay->value || dm_choose->value)) {
+	//show team or weapon menu immediately when connected
+	//gi.dprintf("last refresh: %d, mod refresh: %d, realframenum: %d\n", client->resp.last_motd_refresh, (client->resp.last_motd_refresh * 2), level.realFramenum);
+	if (auto_menu->value == 2) {
+		if (level.realFramenum == (ent->client->resp.last_motd_refresh * 2)) {
+			if (auto_menu->value && ent->client->layout != LAYOUT_MENU && !client->pers.menu_shown && (teamplay->value || dm_choose->value)) {
+				Cmd_Inven_f( ent );
+			}
+		}
+	} else if (auto_menu->value == 1 && ent->client->layout != LAYOUT_MENU && !client->pers.menu_shown && (teamplay->value || dm_choose->value)) {
 		Cmd_Inven_f( ent );
 	}
 

--- a/src/refresh/main.c
+++ b/src/refresh/main.c
@@ -472,10 +472,15 @@ void GL_DrawLine(vec3_t verts, const int num_points, const uint32_t* colors, con
     //GL_StateBits(GLS_BLEND_BLEND | GLS_DEPTHMASK_FALSE);
     GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
     //GL_VertexPointer(3, 0, &verts[0][0]);
-    GL_VertexPointer(3, 0, &v[0][0]);
+    if(!gl_shaders->value) {
+        GL_VertexPointer(3, 0, &v[0][0]);
+    }
+    
     glLineWidth(line_width); // Set the line width
     
-    GL_ColorBytePointer(4, 0, (GLubyte*)colors); // Set the color of the line
+    if(!gl_shaders->value) {
+        GL_ColorBytePointer(4, 0, (GLubyte*)colors); // Set the color of the line
+    }
     if (occluded)
         GL_DepthRange(0, 1); // Set the far clipping plane to 1 (obscured behind walls)
     else
@@ -514,8 +519,10 @@ void GL_DrawCross(vec3_t origin, qboolean occluded)
     GL_BindTexture(0, TEXNUM_WHITE);
     GL_StateBits(GLS_DEFAULT);
     GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
-    GL_ColorBytePointer(4, 0, (GLubyte*)colors);
-    GL_VertexPointer(3, 0, &points[0][0]);
+    if(!gl_shaders->value) {
+        GL_ColorBytePointer(4, 0, (GLubyte*)colors);
+        GL_VertexPointer(3, 0, &points[0][0]);
+    }
     glLineWidth(1); // Set the line width
 
     if (occluded)
@@ -667,7 +674,7 @@ static qboolean ALLOC_BoxPoints(int num_boxes)
 	}
 	else if (num_boxes != drawbox_total)
 	{
-        if (box_points[0] == NULL || box_colors[0] == NULL)
+        if (box_points == NULL || box_colors == NULL)
             return false;
 
         if_null_1 = box_points;
@@ -787,8 +794,10 @@ void GL_DrawBox(vec3_t origin, uint32_t color, vec3_t mins, vec3_t maxs, qboolea
     GL_BindTexture(0, TEXNUM_WHITE);
     GL_StateBits(GLS_DEFAULT);
     GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
-    GL_ColorBytePointer(4, 0, (GLubyte*)colors);
-    GL_VertexPointer(3, 0, &points[0][0]);
+    if(!gl_shaders->value) {
+        GL_ColorBytePointer(4, 0, (GLubyte*)colors);
+        GL_VertexPointer(3, 0, &points[0][0]);
+    }
     glLineWidth(2); // Set the line width
 
     if (occluded)
@@ -875,8 +884,10 @@ static void GL_BatchDrawBoxes(int num_boxes, qboolean occluded)
         GL_BindTexture(0, TEXNUM_WHITE);
         GL_StateBits(GLS_DEFAULT);
         GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
-        GL_ColorBytePointer(4, 0, (GLubyte*)box_colors);
-        GL_VertexPointer(3, 0, &box_points[0][0]);
+        if(!gl_shaders->value) {
+            GL_ColorBytePointer(4, 0, (GLubyte*)box_colors);
+            GL_VertexPointer(3, 0, &box_points[0][0]);
+        }
         glLineWidth(2); // Set the line width
 
         if (occluded)
@@ -1202,8 +1213,10 @@ static void GL_BatchDrawArrows(qboolean occluded)
         GL_BindTexture(0, TEXNUM_WHITE);
         GL_StateBits(GLS_DEFAULT);
         GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
-        GL_VertexPointer(3, 0, &arrow_points[0][0]);
-        GL_ColorBytePointer(4, 0, (GLubyte*)arrow_colors); // Set the color of the line
+        if(!gl_shaders->value) {
+            GL_VertexPointer(3, 0, &arrow_points[0][0]);
+            GL_ColorBytePointer(4, 0, (GLubyte*)arrow_colors); // Set the color of the line
+        }
         //glLineWidth(line_width); // Set the line width
 
         if (occluded)


### PR DESCRIPTION
- `auto_menu` now has a new value of `2`: If set to 2, the menu will appear AFTER the motd is done printing
- Set some gl_shader checks to prevent segfaults on GLSL renderers attempting to use legacy GL calls