### PR TITLE
Fix uncommon spawnpoints

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -406,7 +406,7 @@ game_deps = [zlib]
 
 jpeg = dependency('libjpeg',
   required:        get_option('libjpeg'),
-  default_options: fallback_opt + [ 'jpeg-turbo=disabled', 'tests=disabled' ],
+  default_options: ['default_library=static', 'jpeg-turbo=disabled', 'tests=disabled'],
   static:          true
 )
 

--- a/meson.build
+++ b/meson.build
@@ -404,14 +404,19 @@ client_deps = [png, curl, sdl2]
 server_deps = []
 game_deps = [zlib]
 
-jpeg = dependency('libjpeg',
-  required:        get_option('libjpeg'),
-  default_options: fallback_opt + [ 'jpeg-turbo=disabled', 'tests=disabled' ],
-  # Statically link if we're MacOS
-  if host_machine.system() == 'darwin'
+# Statically link if we're MacOS
+if host_machine.system() == 'darwin'
+  jpeg = dependency('libjpeg',
+    required:        get_option('libjpeg'),
+    default_options: fallback_opt + [ 'jpeg-turbo=disabled', 'tests=disabled' ],
     static: true
-  endif
-)
+  )
+else
+jpeg = dependency('libjpeg',
+    required:        get_option('libjpeg'),
+    default_options: fallback_opt + [ 'jpeg-turbo=disabled', 'tests=disabled' ],
+  )
+endif
 
 if jpeg.found()
   if jpeg.type_name() == 'internal'

--- a/meson.build
+++ b/meson.build
@@ -406,7 +406,11 @@ game_deps = [zlib]
 
 jpeg = dependency('libjpeg',
   required:        get_option('libjpeg'),
-  default_options: fallback_opt + [ 'jpeg-turbo=disabled', 'tests=disabled' ]
+  default_options: fallback_opt + [ 'jpeg-turbo=disabled', 'tests=disabled' ],
+  # Statically link if we're MacOS
+  if host_machine.system() == 'darwin'
+    static: true
+  endif
 )
 
 if jpeg.found()

--- a/meson.build
+++ b/meson.build
@@ -406,7 +406,7 @@ game_deps = [zlib]
 
 jpeg = dependency('libjpeg',
   required:        get_option('libjpeg'),
-  default_options: ['default_library=static', 'jpeg-turbo=disabled', 'tests=disabled'],
+  default_options: {'default_library': 'static', 'jpeg-turbo': 'disabled', 'tests': 'disabled'},
   static:          true
 )
 

--- a/meson.build
+++ b/meson.build
@@ -406,8 +406,7 @@ game_deps = [zlib]
 
 jpeg = dependency('libjpeg',
   required:        get_option('libjpeg'),
-  default_options: {'default_library': 'static', 'jpeg-turbo': 'disabled', 'tests': 'disabled'},
-  static:          true
+  default_options: fallback_opt + [ 'jpeg-turbo=disabled', 'tests=disabled' ]
 )
 
 if jpeg.found()

--- a/src/action/p_client.c
+++ b/src/action/p_client.c
@@ -2176,52 +2176,68 @@ cannot spawn.
 edict_t *UncommonSpawnPoint(void)
 {
 	edict_t *spot = NULL;
+	edict_t *first_valid_spot = NULL;
 
-	if (!spot) {
-		gi.dprintf("Warning: failed to find deathmatch spawn point, unexpected spawns will be utilized\n");
+	/*
+	Try all possible classes of spawn points, and use DM weapon spawns as a last resort.
+	*/
+	char* spawnpoints[] = {
+		"info_player_start",
+		"info_player_coop",
+		"info_player_team1",
+		"info_player_team2",
+		"info_player_team3",
+		"info_player_deathmatch",
+		"weapon_bfg",
+		"weapon_chaingun",
+		"weapon_machinegun",
+		"weapon_rocketlauncher",
+		"weapon_shotgun",
+		"weapon_supershotgun",
+		"weapon_railgun"
+	};
+	size_t num_spawnpoints = sizeof(spawnpoints) / sizeof(spawnpoints[0]);
 
-		/*
-		Try all possible classes of spawn points, and use DM weapon spawns as a last resort.
-		*/
-		char* spawnpoints[] = {
-			"info_player_start",
-			"info_player_coop",
-			"info_player_team1",
-			"info_player_team2",
-			"info_player_team3",
-			"info_player_deathmatch",
-			"weapon_bfg",
-			"weapon_chaingun",
-			"weapon_machinegun",
-			"weapon_rocketlauncher",
-			"weapon_shotgun",
-			"weapon_supershotgun",
-			"weapon_railgun"
-		};
-		size_t num_spawnpoints = sizeof(spawnpoints) / sizeof(spawnpoints[0]);
-		int i;
-		for (i = 0; i < num_spawnpoints; ++i) {
-			while ((spot = G_Find(spot, FOFS(classname), spawnpoints[i])) != NULL) {
-				if (!game.spawnpoint[0] && !spot->targetname)
-					break;
+	// Try each spawn point type in order
+	for (int i = 0; i < num_spawnpoints; ++i) {
+		spot = NULL; // Reset spot for each new spawn point type
 
-				if (!game.spawnpoint[0] || !spot->targetname)
-					continue;
-
-				if (Q_stricmp(game.spawnpoint, spot->targetname) == 0)
-					break;
+		// Find all entities of this type
+		while ((spot = G_Find(spot, FOFS(classname), spawnpoints[i])) != NULL) {
+			// Save the first valid spot we find of any type as a fallback
+			if (!first_valid_spot) {
+				first_valid_spot = spot;
 			}
 
-			if (spot) {
-				gi.dprintf("Warning: Uncommon spawn point of class %s\n", spawnpoints[i]);
-				gi.dprintf("**If you are the map author, you need to be utilizing MULTIPLE info_player_deathmatch or info_player_team entities**\n");
-				break;
+			// If no specific spawn point is requested, any entity without a targetname will do
+			if (!game.spawnpoint[0] && !spot->targetname) {
+				gi.dprintf("Found spawn point of class %s\n", spawnpoints[i]);
+				return spot;
+			}
+
+			// If a specific spawn point is requested, match by targetname
+			if (game.spawnpoint[0] && spot->targetname && 
+				(Q_stricmp(game.spawnpoint, spot->targetname) == 0)) {
+				gi.dprintf("Found requested spawn point %s of class %s\n", 
+					game.spawnpoint, spawnpoints[i]);
+				return spot;
 			}
 		}
 	}
 
-	return spot;
+	// If we get here, we didn't find an ideal spawn point, but we might have a fallback
+	if (first_valid_spot) {
+		gi.dprintf("Warning: failed to find ideal deathmatch spawn point, using fallback spawn\n");
+		gi.dprintf("**If you are the map author, you need to be utilizing MULTIPLE info_player_deathmatch or info_player_team entities**\n");
+		return first_valid_spot;
+	}
+
+	// Truly no spawn points found
+	gi.dprintf("Warning: failed to find ANY spawn point, map is not playable\n");
+	return NULL;
 }
+
+
 
 edict_t *SelectCoopSpawnPoint(edict_t *ent)
 {

--- a/src/refresh/main.c
+++ b/src/refresh/main.c
@@ -472,10 +472,15 @@ void GL_DrawLine(vec3_t verts, const int num_points, const uint32_t* colors, con
     //GL_StateBits(GLS_BLEND_BLEND | GLS_DEPTHMASK_FALSE);
     GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
     //GL_VertexPointer(3, 0, &verts[0][0]);
-    GL_VertexPointer(3, 0, &v[0][0]);
+    if(!gl_shaders->value) {
+        GL_VertexPointer(3, 0, &v[0][0]);
+    }
+    
     glLineWidth(line_width); // Set the line width
     
-    GL_ColorBytePointer(4, 0, (GLubyte*)colors); // Set the color of the line
+    if(!gl_shaders->value) {
+        GL_ColorBytePointer(4, 0, (GLubyte*)colors); // Set the color of the line
+    }
     if (occluded)
         GL_DepthRange(0, 1); // Set the far clipping plane to 1 (obscured behind walls)
     else
@@ -514,8 +519,10 @@ void GL_DrawCross(vec3_t origin, qboolean occluded)
     GL_BindTexture(0, TEXNUM_WHITE);
     GL_StateBits(GLS_DEFAULT);
     GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
-    GL_ColorBytePointer(4, 0, (GLubyte*)colors);
-    GL_VertexPointer(3, 0, &points[0][0]);
+    if(!gl_shaders->value) {
+        GL_ColorBytePointer(4, 0, (GLubyte*)colors);
+        GL_VertexPointer(3, 0, &points[0][0]);
+    }
     glLineWidth(1); // Set the line width
 
     if (occluded)
@@ -667,7 +674,7 @@ static qboolean ALLOC_BoxPoints(int num_boxes)
 	}
 	else if (num_boxes != drawbox_total)
 	{
-        if (box_points[0] == NULL || box_colors[0] == NULL)
+        if (box_points == NULL || box_colors == NULL)
             return false;
 
         if_null_1 = box_points;
@@ -787,8 +794,10 @@ void GL_DrawBox(vec3_t origin, uint32_t color, vec3_t mins, vec3_t maxs, qboolea
     GL_BindTexture(0, TEXNUM_WHITE);
     GL_StateBits(GLS_DEFAULT);
     GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
-    GL_ColorBytePointer(4, 0, (GLubyte*)colors);
-    GL_VertexPointer(3, 0, &points[0][0]);
+    if(!gl_shaders->value) {
+        GL_ColorBytePointer(4, 0, (GLubyte*)colors);
+        GL_VertexPointer(3, 0, &points[0][0]);
+    }
     glLineWidth(2); // Set the line width
 
     if (occluded)
@@ -875,8 +884,10 @@ static void GL_BatchDrawBoxes(int num_boxes, qboolean occluded)
         GL_BindTexture(0, TEXNUM_WHITE);
         GL_StateBits(GLS_DEFAULT);
         GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
-        GL_ColorBytePointer(4, 0, (GLubyte*)box_colors);
-        GL_VertexPointer(3, 0, &box_points[0][0]);
+        if(!gl_shaders->value) {
+            GL_ColorBytePointer(4, 0, (GLubyte*)box_colors);
+            GL_VertexPointer(3, 0, &box_points[0][0]);
+        }
         glLineWidth(2); // Set the line width
 
         if (occluded)
@@ -1202,8 +1213,10 @@ static void GL_BatchDrawArrows(qboolean occluded)
         GL_BindTexture(0, TEXNUM_WHITE);
         GL_StateBits(GLS_DEFAULT);
         GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
-        GL_VertexPointer(3, 0, &arrow_points[0][0]);
-        GL_ColorBytePointer(4, 0, (GLubyte*)arrow_colors); // Set the color of the line
+        if(!gl_shaders->value) {
+            GL_VertexPointer(3, 0, &arrow_points[0][0]);
+            GL_ColorBytePointer(4, 0, (GLubyte*)arrow_colors); // Set the color of the line
+        }
         //glLineWidth(line_width); // Set the line width
 
         if (occluded)


### PR DESCRIPTION
Updated **UncommonSpawnPoint()** such that it will return the first valid spot it finds based on the array of entity string name matches in the map, starting with `info_player_start`.  This only occurs if `info_player_deathmatch` or `team` related spawn entities are not found in the map (usually either non-AQ2 maps or unfinished ones).  This also prints a warning in the console in case the author of the map is not aware.

This merge includes a change to `meson.build` that broke Windows builds, assuming that `static: true` is no longer a valid parameter for building libjpeg.

This merge also includes a few checks for the `gl_shaders` value and whether or not to use legacy GL commands.