### PR TITLE
Autoghost

### DIFF
--- a/doc/action.md
+++ b/doc/action.md
@@ -589,7 +589,7 @@ TNG offers a new spawn code for Teamplay. This mode prevents teams to spawn twic
 With the use of the ghost command, the client can get back when he has been disconnected and get your frags and stats back. Ghost does require the client to have the same nick and ip when using the ghost command.
 
 **Commands:**
-- `use_ghosts [0/1]` - when set to on (1), the server allows the clients to use the ghost command.
+- `use_ghosts [0/1/2]` - when set to on (1), the server allows the clients to use the ghost command.  When set to (2), this with automatically restore ghost data on rejoin (if the ghost exists)
 - `ghost` - this will restore the scores, stats, teams and items of the client. (client side)
 
 ### Bandolier behavior

--- a/doc/action.md
+++ b/doc/action.md
@@ -589,7 +589,7 @@ TNG offers a new spawn code for Teamplay. This mode prevents teams to spawn twic
 With the use of the ghost command, the client can get back when he has been disconnected and get your frags and stats back. Ghost does require the client to have the same nick and ip when using the ghost command.
 
 **Commands:**
-- `use_ghosts [0/1/2]` - when set to on (1), the server allows the clients to use the ghost command.  When set to (2), this with automatically restore ghost data on rejoin (if the ghost exists)
+- `use_ghosts [0/1/2]` - when set to on (1), the server allows the clients to use the ghost command.  When set to (2), this will automatically restore ghost data on rejoin (if the ghost exists)
 - `ghost` - this will restore the scores, stats, teams and items of the client. (client side)
 
 ### Bandolier behavior

--- a/src/action/a_cmds.c
+++ b/src/action/a_cmds.c
@@ -1264,6 +1264,9 @@ qboolean Ghost_Exist(edict_t *ent)
 	int i;
 	gghost_t *ghost;
 
+	if (!use_ghosts->value || num_ghost_players == 0)
+		return false;
+
 	for (i = 0, ghost = ghost_players; i < num_ghost_players; i++, ghost++) {
 		if (!strcmp(ghost->ip, ent->client->pers.ip) && !strcmp(ghost->netname, ent->client->pers.netname)) {
 			return true;

--- a/src/action/a_cmds.c
+++ b/src/action/a_cmds.c
@@ -1258,6 +1258,20 @@ Cmd_Ghost_f
 
 Person gets frags/kills/damage/weapon/item/team/stats back if he disconnected
 */
+
+qboolean Ghost_Exist(edict_t *ent)
+{
+	int i;
+	gghost_t *ghost;
+
+	for (i = 0, ghost = ghost_players; i < num_ghost_players; i++, ghost++) {
+		if (!strcmp(ghost->ip, ent->client->pers.ip) && !strcmp(ghost->netname, ent->client->pers.netname)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void Cmd_Ghost_f(edict_t * ent)
 {
 	int i = 0, frames_since = 0;

--- a/src/action/a_cmds.c
+++ b/src/action/a_cmds.c
@@ -1268,7 +1268,8 @@ qboolean Ghost_Exist(edict_t *ent)
 		return false;
 
 	for (i = 0, ghost = ghost_players; i < num_ghost_players; i++, ghost++) {
-		if (!strcmp(ghost->ip, ent->client->pers.ip) && !strcmp(ghost->netname, ent->client->pers.netname)) {
+		if (ghost->ip && ent->client->pers.ip && ghost->netname && ent->client->pers.netname &&
+			!strcmp(ghost->ip, ent->client->pers.ip) && !strcmp(ghost->netname, ent->client->pers.netname)) {
 			return true;
 		}
 	}

--- a/src/action/p_client.c
+++ b/src/action/p_client.c
@@ -3660,10 +3660,20 @@ qboolean ClientConnect(edict_t * ent, char *userinfo)
 	//guarantee a client is actually making it all the way into the game.
 	//ent->client->pers.connected = true;
 
+	qboolean is_bot = false;
 	#ifndef NO_BOTS
 	if(bot_chat->value)
 		BOTLIB_Chat(ent, CHAT_WELCOME);
+
+	if (IS_BOT(ent))
+		is_bot = true;
 	#endif
+
+	if (!is_bot && use_ghosts->value == 2) {
+		if (Ghost_Exist(ent)) {
+			Cmd_Ghost_f(ent);
+		}
+	}
 
 	return true;
 }

--- a/src/refresh/main.c
+++ b/src/refresh/main.c
@@ -472,10 +472,15 @@ void GL_DrawLine(vec3_t verts, const int num_points, const uint32_t* colors, con
     //GL_StateBits(GLS_BLEND_BLEND | GLS_DEPTHMASK_FALSE);
     GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
     //GL_VertexPointer(3, 0, &verts[0][0]);
-    GL_VertexPointer(3, 0, &v[0][0]);
+    if(!gl_shaders->value) {
+        GL_VertexPointer(3, 0, &v[0][0]);
+    }
+    
     glLineWidth(line_width); // Set the line width
     
-    GL_ColorBytePointer(4, 0, (GLubyte*)colors); // Set the color of the line
+    if(!gl_shaders->value) {
+        GL_ColorBytePointer(4, 0, (GLubyte*)colors); // Set the color of the line
+    }
     if (occluded)
         GL_DepthRange(0, 1); // Set the far clipping plane to 1 (obscured behind walls)
     else
@@ -514,8 +519,10 @@ void GL_DrawCross(vec3_t origin, qboolean occluded)
     GL_BindTexture(0, TEXNUM_WHITE);
     GL_StateBits(GLS_DEFAULT);
     GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
-    GL_ColorBytePointer(4, 0, (GLubyte*)colors);
-    GL_VertexPointer(3, 0, &points[0][0]);
+    if(!gl_shaders->value) {
+        GL_ColorBytePointer(4, 0, (GLubyte*)colors);
+        GL_VertexPointer(3, 0, &points[0][0]);
+    }
     glLineWidth(1); // Set the line width
 
     if (occluded)
@@ -667,7 +674,7 @@ static qboolean ALLOC_BoxPoints(int num_boxes)
 	}
 	else if (num_boxes != drawbox_total)
 	{
-        if (box_points[0] == NULL || box_colors[0] == NULL)
+        if (box_points == NULL || box_colors == NULL)
             return false;
 
         if_null_1 = box_points;
@@ -787,8 +794,10 @@ void GL_DrawBox(vec3_t origin, uint32_t color, vec3_t mins, vec3_t maxs, qboolea
     GL_BindTexture(0, TEXNUM_WHITE);
     GL_StateBits(GLS_DEFAULT);
     GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
-    GL_ColorBytePointer(4, 0, (GLubyte*)colors);
-    GL_VertexPointer(3, 0, &points[0][0]);
+    if(!gl_shaders->value) {
+        GL_ColorBytePointer(4, 0, (GLubyte*)colors);
+        GL_VertexPointer(3, 0, &points[0][0]);
+    }
     glLineWidth(2); // Set the line width
 
     if (occluded)
@@ -875,8 +884,10 @@ static void GL_BatchDrawBoxes(int num_boxes, qboolean occluded)
         GL_BindTexture(0, TEXNUM_WHITE);
         GL_StateBits(GLS_DEFAULT);
         GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
-        GL_ColorBytePointer(4, 0, (GLubyte*)box_colors);
-        GL_VertexPointer(3, 0, &box_points[0][0]);
+        if(!gl_shaders->value) {
+            GL_ColorBytePointer(4, 0, (GLubyte*)box_colors);
+            GL_VertexPointer(3, 0, &box_points[0][0]);
+        }
         glLineWidth(2); // Set the line width
 
         if (occluded)
@@ -1202,8 +1213,10 @@ static void GL_BatchDrawArrows(qboolean occluded)
         GL_BindTexture(0, TEXNUM_WHITE);
         GL_StateBits(GLS_DEFAULT);
         GL_ArrayBits(GLA_VERTEX | GLA_COLOR);
-        GL_VertexPointer(3, 0, &arrow_points[0][0]);
-        GL_ColorBytePointer(4, 0, (GLubyte*)arrow_colors); // Set the color of the line
+        if(!gl_shaders->value) {
+            GL_VertexPointer(3, 0, &arrow_points[0][0]);
+            GL_ColorBytePointer(4, 0, (GLubyte*)arrow_colors); // Set the color of the line
+        }
         //glLineWidth(line_width); // Set the line width
 
         if (occluded)


### PR DESCRIPTION
Adjusted server setting `use_ghosts` to enable a '2' value.  Value '2' automatically restores ghosts for players without needing to type 'ghost'.  This only applies to players with ghost data.  Bots are excluded.