### PR TITLE
fix(#316) Tier 2: matchmode timeout/abandon/timeoutcount fixes

### DIFF
--- a/src/action/a_match.c
+++ b/src/action/a_match.c
@@ -421,6 +421,13 @@ qboolean CheckAbandon(void)
 	if (!matchmode->value || !use_forfeit->value)
 		return false;
 
+	/* Treat forfeit_abandon_time <= 0 as "abandonment detection disabled".
+	 * Without this guard, abandonFrames becomes 0 in the registration path,
+	 * the `!level.abandonFrames` branch fires every server tick, and the
+	 * announcement spams the log forever. */
+	if (forfeit_abandon_time->value <= 0)
+		return false;
+
 	if (!team_game_going)
 		return false;
 
@@ -908,7 +915,10 @@ void Cmd_CallTimeout_f(edict_t * ent)
 		return;
 	}
 
-	if (level.matchTime >= timelimit->value * 60) {
+	/* Skip the last-round guard when timelimit is unlimited (0). Otherwise
+	 * `matchTime >= 0` is always true and timeouts are blocked permanently
+	 * on unlimited-time servers. */
+	if (timelimit->value > 0 && level.matchTime >= timelimit->value * 60) {
 		gi.cprintf(ent, PRINT_HIGH, "You cannot call for a timeout on the last round of the match\n");
 		return;
 	}

--- a/src/action/g_save.c
+++ b/src/action/g_save.c
@@ -490,7 +490,7 @@ void InitGame( void )
 	mm_allowlock = gi.cvar( "mm_allowlock", "1", CVAR_LATCH );
 	mm_pausecount = gi.cvar( "mm_allowcount", "3", CVAR_LATCH );
 	mm_pausetime = gi.cvar( "mm_pausetime", "2", CVAR_LATCH );
-	mm_timeoutcount = gi.cvar( "mm_timeoutcount", "1", CVAR_LATCH ); // 1 timeout
+	mm_timeoutcount = gi.cvar( "mm_timeoutcount", "2", CVAR_LATCH ); // 2 timeouts per team per match
 	mm_timeouttime = gi.cvar( "mm_timeouttime", "60", CVAR_LATCH ); // 60 seconds
 	use_forfeit = gi.cvar( "use_forfeit", "0", 0 ); // Enable forfeit command
 	forfeit_abandon_time = gi.cvar( "forfeit_abandon_time", "60", 0 ); // Abandon timer in seconds


### PR DESCRIPTION
## Summary

Tier 2 of the issue #316 audit fixes — high-impact bugs in the matchmode/forfeit/timeout system.

Resolves:

- **FIX-05** — `mm_timeoutcount` source default was `1`, doc said `2` — admins got fewer timeouts than expected
- **FIX-06** — `timeout` cmd was permanently blocked on unlimited-time servers (timelimit=0 made the last-round guard always true)
- **FIX-07** — `forfeit_abandon_time = 0` caused infinite log spam every server tick

Reviewed but **not implemented**:

- **FIX-04** — resolved by the sync PR (#317). `mm_carryover` is now present from the merge of `aqtion-alpha`.
- **FIX-08** — on closer inspection, the proposed `use_ghosts 2` double-ghost bug does not actually occur. `CreateGhost` (p_client.c:4015-4020) is idempotent: it de-duplicates by ip+name and updates the existing record rather than appending. `Cmd_Ghost_f` (a_cmds.c:1336-1340) removes the ghost record from the array on restoration. So after an autoghost restore + subsequent disconnect, only one ghost record exists. The proposed fix (skipping `CreateGhost` after autoghost) would actively introduce stat loss for that connection. Recommend closing FIX-08 as "not a bug" in the audit issue.

## Behavioral changes

- `mm_timeoutcount` now defaults to 2 (was 1). Matches documentation. Operators who already set this in `server.cfg` are unaffected.
- `Cmd_CallTimeout_f` now skips the last-round guard when `timelimit <= 0`. Time-limited matches behave identically.
- `CheckAbandon` returns early when `forfeit_abandon_time <= 0`. This effectively disables abandonment detection — document `0` as the "disabled" value.

## Base

Branched from `fix/316-sync` (PR #317). Land that first; this branch will rebase cleanly onto `aqtion` afterward.

## Test plan

- [ ] Boot matchmode server with no `mm_timeoutcount` set. Verify cvarlist shows `2`.
- [ ] Run a matchmode match with `timelimit 0`. Captain calls `timeout`. Verify it works (was previously blocked).
- [ ] Run matchmode match with `timelimit 20`. Captain calls `timeout` after 20 minutes elapsed. Verify it's still blocked (last-round guard).
- [ ] Set `forfeit_abandon_time 0`, start matchmode match, have all players leave. Verify no log spam, no abandonment-detected message firing each tick.
- [ ] Set `forfeit_abandon_time 60` (default), repeat — verify normal abandonment behavior still works.

## Files changed

- `src/action/g_save.c` — `mm_timeoutcount` default 1 → 2
- `src/action/a_match.c` — `Cmd_CallTimeout_f` timelimit guard, `CheckAbandon` early-return on zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)
