### PR TITLE
fix(#316) Tier 3: medium-impact fixes (teamnone, captain broadcast, RulesExt cache, LRCON paths)

### DIFF
--- a/src/action/a_game.c
+++ b/src/action/a_game.c
@@ -1660,12 +1660,21 @@ void ReadLrconConfig(void)
 	game.lrcon_config.allowed_cvars_count = 0;
 	game.lrcon_config.modes_count = 0;
 
-	// Get config filename from cvar
+	// Get config filename from cvar.
+	// Validate value: must be a plain filename within the action/ directory.
+	// Without this, lrcon_config "../../../etc/crontab" would open arbitrary
+	// filesystem paths. Also replaces unbounded sprintf with Q_snprintf.
 	lrcon_config_cvar = gi.cvar("lrcon_config", "lrcon.cfg", 0);
-	if (lrcon_config_cvar->string && *(lrcon_config_cvar->string))
-		sprintf(cfgpath, "%s/%s", GAMEVERSION, lrcon_config_cvar->string);
-	else
-		sprintf(cfgpath, "%s/%s", GAMEVERSION, "lrcon.cfg");
+	{
+		const char *name = (lrcon_config_cvar->string && *lrcon_config_cvar->string)
+			? lrcon_config_cvar->string : "lrcon.cfg";
+		if (strstr(name, "..") || strchr(name, '/') || strchr(name, '\\') ||
+		    strchr(name, ':')) {
+			gi.dprintf("LRCON: refusing lrcon_config '%s' — must be a plain filename within action/\n", name);
+			return;
+		}
+		Q_snprintf(cfgpath, sizeof(cfgpath), "%s/%s", GAMEVERSION, name);
+	}
 
 	// Try to open config file
 	config_file = fopen(cfgpath, "r");

--- a/src/action/a_match.c
+++ b/src/action/a_match.c
@@ -656,7 +656,10 @@ void Cmd_Teamnone_f(edict_t *ent)
 		return;
 	}
 
-	if (gi.argc() < 1) {
+	/* gi.argc() always returns at least 1 (the command name itself), so the
+	 * previous `< 1` guard was dead code — missing-arg silently fell through
+	 * with playernum=0 from atoi(""). */
+	if (gi.argc() < 2) {
 		gi.cprintf(ent, PRINT_HIGH, "You need to provide a playernum for this command\nUse 'playerlist' to get a list of playernums\n");
 		return;
 	}

--- a/src/action/p_client.c
+++ b/src/action/p_client.c
@@ -3849,11 +3849,14 @@ qboolean ClientConnect(edict_t * ent, char *userinfo)
 		IRC_printf(IRC_T_SERVER, "%n@%s connected", value, ipaddr_buf);
 	}
 
-	// LRCON: Check if reconnecting claimer and restore claim
+	// LRCON: Check if reconnecting claimer and restore claim.
+	// Use Q_stricmp to match Lrcon_CheckClaimer's case-insensitive compare;
+	// otherwise a claimer reconnecting as "admin" (was "Admin") passes the
+	// permission check at command time but silently fails restore here.
 	value = Info_ValueForKey(userinfo, "name");
 	if (game.lrcon_config.enabled && lrcon_claimer_name->string && *lrcon_claimer_name->string &&
-		!strcmp(lrcon_claimer_name->string, value) &&
-		!strcmp(lrcon_claimer_ip->string, ipaddr_buf)) {
+		!Q_stricmp(lrcon_claimer_name->string, value) &&
+		!Q_stricmp(lrcon_claimer_ip->string, ipaddr_buf)) {
 		level.lrcon.claimed = true;
 		Q_strncpyz(level.lrcon.claimer_name, lrcon_claimer_name->string,
 				   sizeof(level.lrcon.claimer_name));
@@ -3913,7 +3916,12 @@ void ClientDisconnect(edict_t * ent)
 	if (!ent->client)
 		return;
 
-	if (esp->value && matchmode->value) {
+	/* Only fire the captain-disconnect broadcast for actual captains.
+	 * Previously this ran for every disconnect from an esp+matchmode game,
+	 * including spectators (resp.team == NOTEAM), which would read
+	 * teams[NOTEAM].name — empty/stale slot. */
+	if (esp->value && matchmode->value &&
+	    ent->client->resp.team != NOTEAM && IS_CAPTAIN(ent)) {
 		char tempmsg[128];
 		// We have to kill him first before he is removed as captain/leader
 		killPlayer(ent, false);

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -914,8 +914,14 @@ static void SVC_RulesExt(void)
         return;
     }
 
-    // Check if we need to rebuild the cache
-    if (svs.realtime - rulesext_cache.timestamp > RULESEXT_CACHE_TIME) {
+    // Check if we need to rebuild the cache.
+    // Force a build on first use (chunk_count == 0): otherwise during the
+    // first RULESEXT_CACHE_TIME (~5s) of uptime, svs.realtime and timestamp
+    // are both 0 so the staleness check is false and the cache stays empty,
+    // leaving all chunk replies empty until the threshold passes.
+    // Mirrors the SVC_StatusExt build-condition.
+    if (!rulesext_cache.chunk_count ||
+        svs.realtime - rulesext_cache.timestamp > RULESEXT_CACHE_TIME) {
         len = SV_BuildExtendedRules(rulesext_cache.data, sizeof(rulesext_cache.data));
         rulesext_cache.total_size = len;
         rulesext_cache.chunk_count = (len + RULESEXT_CHUNK_SIZE - 1) / RULESEXT_CHUNK_SIZE;


### PR DESCRIPTION
## Summary

Tier 3 of the issue #316 audit fixes — medium-impact bugs across matchmode, LRCON, and the server engine.

Resolves:

- **FIX-10** — `teamnone` missing-arg guard was dead code; could silently kick player 0
- **FIX-11** — `ClientDisconnect` captain-disconnect broadcast fired for every disconnect (incl. spectators), accessing `teams[NOTEAM].name`
- **FIX-12** — `SVC_RulesExt` cache never built during first ~5s of server uptime; chunk replies were empty
- **FIX-13** — LRCON claimer comparator inconsistency (`strcmp` vs `Q_stricmp`) caused silent reconnect-restore failures and case-swap impersonation gap
- **FIX-14** — `ReadLrconConfig` accepted path traversal in `lrcon_config` cvar

## Behavioral changes

- `teamnone` without an arg now prints the usage hint (was silently failing or kicking player 0).
- The "Captain disconnected" broadcast only fires when an actual captain disconnects.
- Server-browser tools querying a freshly-started server now get a populated RulesExt response immediately.
- A claimer can reconnect with any-case version of their original name and have their claim auto-restored (was silently failing if case differed).
- `lrcon_config` cvar containing `..`, `/`, `\`, or `:` is rejected at startup with a dprintf warning.

## Base

Branched from `fix/316-sync` (PR #317). Land that first; this branch will rebase cleanly onto `aqtion` afterward.

## Test plan

- [ ] Captain types `teamnone` with no arg — verify usage hint appears.
- [ ] Spectator (team 0) disconnects from an esp+matchmode server — verify no spurious "captain disconnected" broadcast.
- [ ] Start server with `sv_status_ext 1`. Immediately query Extended Rules — verify chunk_count > 0 and data is returned (was empty for first 5s).
- [ ] Claim as `Admin`, disconnect, reconnect as `admin` from same IP — verify claim auto-restored.
- [ ] Set `lrcon_config "../foo"` in server config — verify startup rejects with dprintf, LRCON disabled.
- [ ] Verify previously-working flows (`teamnone 3`, captain disconnect during match, normal RulesExt after server warmup, same-case claim reconnect, plain `lrcon.cfg` filename) all still work.

## Files changed

- `src/action/a_match.c` — `Cmd_Teamnone_f` arg guard fix
- `src/action/p_client.c` — captain-disconnect broadcast guard, claimer-restore comparator
- `src/action/a_game.c` — `ReadLrconConfig` validation + Q_snprintf
- `src/server/main.c` — `SVC_RulesExt` cache-build condition

## Commit organization note

FIX-13's `strcmp → Q_stricmp` change in `p_client.c` ended up in the same commit as the FIX-10/FIX-11 changes (both touch `p_client.c`). The commit message reflects the file scope, not the strict per-fix split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
