### PR TITLE
fix(#316) Tier 4: nits + quit_on_empty race fix + dead cvar cleanup

### DIFF
--- a/src/action/a_esp.h
+++ b/src/action/a_esp.h
@@ -1,10 +1,6 @@
 // This is set to 1 if either atl or etv are 1
 extern cvar_t *esp;
 
-// Discrete game modes
-extern cvar_t *atl;
-extern cvar_t *etv;
-
 #define IS_LEADER(ent) (teams[(ent)->client->resp.team].leader == (ent))
 #define	HAVE_LEADER(teamNum) (teams[(teamNum)].leader)
 #define MAX_ESP_STRLEN 32

--- a/src/action/g_local.h
+++ b/src/action/g_local.h
@@ -976,6 +976,7 @@ typedef struct
   int timeoutFrames;
   float matchTime;
   float emptyTime;
+  float quit_empty_time;  // LRCON quit_on_empty: level.time when server first emptied, or -1 if not empty. Separate from emptyTime which empty_rotate uses as an accumulator.
   int abandonFrames;  // Countdown for abandon forfeit
   int weapon_sound_framenum;
   int pic_teamplay_timer_icon;
@@ -1396,8 +1397,6 @@ extern cvar_t *medkit_value;
 
 // BEGIN AQ2 ETE
 extern cvar_t *esp;  // Enable or disable Espionage mode
-extern cvar_t *atl;  // Enable or disable Assassinate the Leader mode (do not set this manually)
-extern cvar_t *etv;	 // Enable or disable Escort the VIP mode (do not set this manually)
 extern cvar_t *esp_atl;  // Prefer ATL mode even if ETV mode is available
 extern cvar_t *esp_punish;  // Enable or disable punishment for losing the around
 extern cvar_t *esp_etv_halftime;  // Enable or disable halftime in ETV mode

--- a/src/action/g_main.c
+++ b/src/action/g_main.c
@@ -533,8 +533,6 @@ cvar_t *jump;			// jumping mod
 
 // BEGIN AQ2 ETE
 cvar_t *esp;
-cvar_t *atl;
-cvar_t *etv;
 cvar_t *esp_atl;
 cvar_t *esp_punish;
 cvar_t *esp_etv_halftime;
@@ -1344,18 +1342,24 @@ void G_RunFrame (void)
 		return;
 	}
 
-	// LRCON quit_on_empty logic
+	// LRCON quit_on_empty logic.
+	// Uses its own quit_empty_time field — sharing level.emptyTime with the
+	// empty_rotate accumulator above caused the old comparison
+	// `level.time - level.emptyTime > 5.0` to fire after one frame when a
+	// player left a long-running server (level.time was already large but
+	// emptyTime had just incremented from 0). Sentinel -1.0f means "not
+	// currently empty" so we can distinguish from level.time == 0 at start.
 	if (game.lrcon_config.quit_on_empty) {
 		if (empty) {
-			if (level.emptyTime == 0) {
-				level.emptyTime = level.time;
+			if (level.quit_empty_time < 0) {
+				level.quit_empty_time = level.time;
 				gi.dprintf("LRCON: Server empty, will quit in 5 seconds\n");
-			} else if (level.time - level.emptyTime > 5.0) {
+			} else if (level.time - level.quit_empty_time > 5.0f) {
 				gi.dprintf("LRCON: Quitting server (empty for 5+ seconds)\n");
 				gi.AddCommandString("quit\n");
 			}
 		} else {
-			level.emptyTime = 0;
+			level.quit_empty_time = -1.0f;
 		}
 	}
 

--- a/src/action/g_save.c
+++ b/src/action/g_save.c
@@ -618,7 +618,7 @@ void InitGame( void )
 	esp_matchmode = gi.cvar("esp_matchmode", "0", 0);
 	esp_respawn_uvtime = gi.cvar("esp_respawn_uvtime", "10", 0);
 	if (esp_respawn_uvtime->value > 20) {
-		gi.dprintf("esp_respawn_uvtime was set too high, setting to 2 seconds\n");
+		gi.dprintf("esp_respawn_uvtime was set too high, setting to 20 seconds\n");
 		gi.cvar_forceset("esp_respawn_uvtime", "20");
 	}
 	esp_debug = gi.cvar("esp_debug", "0", 0); // Set to 1 to enable debug messages for Espionage

--- a/src/action/g_spawn.c
+++ b/src/action/g_spawn.c
@@ -1580,6 +1580,10 @@ void SpawnEntities (const char *mapname, const char *entities, const char *spawn
 	memset(&level, 0, sizeof (level));
 	memset(g_edicts, 0, game.maxentities * sizeof (g_edicts[0]));
 
+	// quit_empty_time uses -1 as the "not currently empty" sentinel (0 is a
+	// valid level.time at start of map).
+	level.quit_empty_time = -1.0f;
+
 	Q_strncpyz(level.mapname, mapname, sizeof(level.mapname));
 	Q_strncpyz(game.spawnpoint, spawnpoint, sizeof(game.spawnpoint));
 

--- a/src/server/init.c
+++ b/src/server/init.c
@@ -481,6 +481,11 @@ void SV_InitGame(unsigned mvd_spawn)
         SV_MvdPostInit();
     }
 
+    // Reset bot client slots on game (re)initialization. Cold-start gets
+    // zeroed bot_clients[] via BSS, but SV_InitGame can be called on
+    // restart/map-change where in-progress state could otherwise persist.
+    SV_BotInit();
+
     if (svs.csr.extended && IS_NEW_GAME_API)
         PmoveEnableExt(&svs.pmp);
 


### PR DESCRIPTION
## Summary

Tier 4 of the issue #316 audit fixes — nits, cleanup, and one upgraded-scope fix where the audit's defensive sentinel turned out to mask a real race.

Resolves:

- **FIX-15** — `esp_respawn_uvtime` clamp log message said "setting to 2 seconds" but code set 20
- **FIX-16** — `SV_BotInit` was declared and exported but never called from `SV_InitGame`
- **FIX-17** — `quit_on_empty` timer shared `level.emptyTime` with `empty_rotate`, causing it to fire after one frame on long-running servers (upgraded from "sentinel cleanup")
- **FIX-18** — Dead `atl` / `etv` cvar pointers (replaced by `esp_atl` in 2024) left in g_main.c, g_local.h, a_esp.h

Note: FIX-19 (lrcon.cfg.example operator warnings) shipped with the Tier 1 PR (#318) since it was tied directly to the LRCON allowlist work.

## FIX-17 scope upgrade

The audit flagged `quit_on_empty`'s use of `0.0f` as a sentinel against `level.time`, calling it "fragile but currently harmless". A closer look turned up a real bug: `level.emptyTime` is *also* used by the `empty_rotate` feature as a frame-by-frame accumulator. The two features stomp on each other:

1. Frame N: server becomes empty. `empty_rotate` sets `emptyTime += FRAMETIME` → ~0.1
2. Same frame: `quit_on_empty` checks `level.time - emptyTime > 5.0`. If the server has been running for a while, `level.time` is large, `emptyTime` is ~0.1 → fires immediately (instead of waiting 5 seconds).

Fix: add a dedicated `quit_empty_time` field with a `-1.0f` sentinel. Leave `emptyTime` to `empty_rotate` exclusively.

## Behavioral changes

- `esp_respawn_uvtime > 20` now logs the correct clamp value (20s, not 2s).
- `SV_BotInit` now runs on every game (re)init — bot client slots reset cleanly on map change / server restart.
- `quit_on_empty` now correctly waits 5 seconds after the last player leaves before quitting, regardless of `empty_rotate` setting or server uptime.
- Setting `atl` or `etv` cvars in old configs no longer creates the dead pointers (was already a no-op; now the symbols don't exist).

## Base

Branched from `fix/316-sync` (PR #317). Land that first; this branch will rebase cleanly onto `aqtion` afterward.

## Test plan

- [ ] Set `esp_respawn_uvtime 30` and check server console output — verify log shows "setting to 20 seconds".
- [ ] Set `lrcon.cfg` with `quit_on_empty 1`. Run the server for 10+ minutes with no players (or with a player who connects and leaves). When the server empties, verify it waits **5 seconds** before quitting (not 1 frame).
- [ ] With `empty_rotate 5` (5 min idle → map rotate) and `quit_on_empty 1` both enabled, verify both features work independently.
- [ ] Verify nothing else broke from the `atl`/`etv` pointer removal — grep confirmed no other code references them, but a clean build is a good check.
- [ ] Verify SV_BotInit doesn't crash on map change with bots present.

## Files changed

- `src/action/g_save.c` — esp_respawn_uvtime log string
- `src/action/g_main.c` — quit_on_empty rewrite + dead `atl`/`etv` defs removed
- `src/action/g_local.h` — `quit_empty_time` field added, dead `atl`/`etv` externs removed
- `src/action/g_spawn.c` — quit_empty_time init to -1.0f
- `src/action/a_esp.h` — dead `atl`/`etv` externs removed
- `src/server/init.c` — SV_BotInit() called from SV_InitGame

## Commit organization note

`g_main.c` ended up touching both FIX-17 (quit_on_empty) and FIX-18 (cvar deletes); the first commit's message lists all three FIXes. The supporting g_local.h field addition for FIX-17 came along with FIX-18's externs removal. Net diff is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
